### PR TITLE
feat: refactor alerts screen and add self-contained models

### DIFF
--- a/app/lib/core/network/dio_provider.dart
+++ b/app/lib/core/network/dio_provider.dart
@@ -8,13 +8,13 @@ import 'dart:async';
 import 'dart:collection';
 
 // For physical device testing, use the local IP address of your machine
-const String BASE_URL = "http://192.168.0.173:8000/api/v1";
+// const String BASE_URL = "http://192.168.0.173:8000/api/v1";
 
 // Base URL configuration
 // const String BASE_URL = "http://10.0.2.2:8000/api/v1";
 
 // for mac
-// const String BASE_URL = "http://127.0.0.1:8000/api/v1";
+const String BASE_URL = "http://127.0.0.1:8000/api/v1";
 
 // Request limiter to prevent connection pool exhaustion
 class RequestLimiter extends Interceptor {


### PR DESCRIPTION
Refactor the Alerts screen into a single, stateful AlertsScreen with its own lightweight alert models and layout logic. Replace fragmented controllers and multiple page controllers with a single PageController and responsive _itemsPerPage_ logic that adapts to screen height. Introduce UpcomingAlert and AlertPriority enums to model alerts in this file for a self-contained example, and populate example dummy data.

Rationalize names and state:
- Rename widgets/state classes to AlertsScreen/_AlertsScreenState for clarity.
- Consolidate paging and selected tab tracking into fewer fields.
- Remove numerous legacy alert model imports and inline simple models for the example.

UI / data behavior changes:
- Use dynamic items-per-page calculation (screen-size aware) instead of a fixed _alertsPerPage constant.
- Simplify sample data to UpcomingAlert instances with structured fields (medicineName, patientName, time, dosage, frequency, priority, icon).

This prepares the screen for further UI improvements and real model extraction to separate files.